### PR TITLE
Add Ygdrassil-driven landing and calculators

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,42 +1,17 @@
 #root {
-  max-width: 1280px;
+  max-width: 800px;
   margin: 0 auto;
   padding: 2rem;
   text-align: center;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+nav {
+  margin-top: 1rem;
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
 }
 
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
+label {
+  margin-bottom: 0.25rem;
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,35 +1,22 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
+import { StateMachine, State } from 'ygdrassil'
+import Landing from './pages/Landing.jsx'
+import AlchemyCalculator from './pages/AlchemyCalculator.jsx'
+import SmithingCalculator from './pages/SmithingCalculator.jsx'
 import './App.css'
 
-function App() {
-  const [count, setCount] = useState(0)
-
+export default function App() {
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    <StateMachine name="pages" initial="landing">
+      <State name="landing">
+        <Landing />
+      </State>
+      <State name="alchemy">
+        <AlchemyCalculator />
+      </State>
+      <State name="smithing">
+        <SmithingCalculator />
+      </State>
+    </StateMachine>
   )
 }
 
-export default App

--- a/src/pages/AlchemyCalculator.jsx
+++ b/src/pages/AlchemyCalculator.jsx
@@ -1,0 +1,55 @@
+import { useState } from 'react'
+import { StateLink } from 'ygdrassil'
+
+const potions = [
+  { name: 'Health Potion', ingredients: ['Blue Mountain Flower', 'Wheat'] },
+  { name: 'Fortify Smithing', ingredients: ['Blisterwort', 'Spriggan Sap'] },
+  { name: 'Fortify Barter', ingredients: ['Tundra Cotton', 'Blue Butterfly Wing'] },
+]
+
+const allIngredients = Array.from(new Set(potions.flatMap(p => p.ingredients))).sort()
+
+export default function AlchemyCalculator() {
+  const [selected, setSelected] = useState([])
+
+  const toggleIngredient = (ing) => {
+    setSelected(prev =>
+      prev.includes(ing) ? prev.filter(i => i !== ing) : [...prev, ing],
+    )
+  }
+
+  const results = potions.filter(p => p.ingredients.every(ing => selected.includes(ing)))
+
+  return (
+    <div>
+      <h2>Alchemy Calculator</h2>
+      <p>Select ingredients to see matching potions.</p>
+      <div>
+        {allIngredients.map(ing => (
+          <label key={ing} style={{ display: 'block' }}>
+            <input
+              type="checkbox"
+              checked={selected.includes(ing)}
+              onChange={() => toggleIngredient(ing)}
+            />
+            {ing}
+          </label>
+        ))}
+      </div>
+      <div>
+        <h3>Matching Potions</h3>
+        {results.length ? (
+          <ul>
+            {results.map(p => (
+              <li key={p.name}>{p.name}</li>
+            ))}
+          </ul>
+        ) : (
+          <p>No potions match the selected ingredients.</p>
+        )}
+      </div>
+      <StateLink to="landing">Back to menu</StateLink>
+    </div>
+  )
+}
+

--- a/src/pages/Landing.jsx
+++ b/src/pages/Landing.jsx
@@ -1,0 +1,16 @@
+import { StateLink } from 'ygdrassil'
+
+export default function Landing() {
+  return (
+    <div>
+      <h1>Skyrim Tools</h1>
+      <p>Select a tool:</p>
+      <nav>
+        <StateLink to="alchemy">Alchemy Calculator</StateLink>
+        {' | '}
+        <StateLink to="smithing">Smithing Calculator</StateLink>
+      </nav>
+    </div>
+  )
+}
+

--- a/src/pages/SmithingCalculator.jsx
+++ b/src/pages/SmithingCalculator.jsx
@@ -1,0 +1,42 @@
+import { useState } from 'react'
+import { StateLink } from 'ygdrassil'
+
+const items = [
+  { name: 'Iron Sword', materials: { 'Iron Ingot': 1, 'Leather Strips': 1 } },
+  {
+    name: 'Steel Armor',
+    materials: { 'Steel Ingot': 5, 'Iron Ingot': 1, 'Leather Strips': 3 },
+  },
+]
+
+export default function SmithingCalculator() {
+  const [selected, setSelected] = useState(items[0].name)
+
+  const item = items.find(i => i.name === selected)
+
+  return (
+    <div>
+      <h2>Smithing Calculator</h2>
+      <p>Choose an item to see required materials.</p>
+      <select value={selected} onChange={e => setSelected(e.target.value)}>
+        {items.map(i => (
+          <option key={i.name} value={i.name}>
+            {i.name}
+          </option>
+        ))}
+      </select>
+      <div>
+        <h3>Materials</h3>
+        <ul>
+          {Object.entries(item.materials).map(([mat, qty]) => (
+            <li key={mat}>
+              {mat}: {qty}
+            </li>
+          ))}
+        </ul>
+      </div>
+      <StateLink to="landing">Back to menu</StateLink>
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- Use a Ygdrassil state machine to manage navigation between pages
- Implement basic alchemy and smithing calculators with sample data
- Simplify styling for new tools interface

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5ed10e8c88327b0130bf5beec61fb