### PR TITLE
Add Ygdrassil state pages for Skyrim calculators

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,35 +1,22 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
 import './App.css'
+import { StateMachine, State } from 'ygdrassil'
+import Landing from './pages/Landing.jsx'
+import Alchemy from './pages/Alchemy.jsx'
+import Smithing from './pages/Smithing.jsx'
 
-function App() {
-  const [count, setCount] = useState(0)
-
+export default function App() {
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    <StateMachine name="skyrim" initial="landing" className="app">
+      <State name="landing">
+        <Landing />
+      </State>
+      <State name="alchemy">
+        <Alchemy />
+      </State>
+      <State name="smithing">
+        <Smithing />
+      </State>
+    </StateMachine>
   )
 }
 
-export default App

--- a/src/pages/Alchemy.jsx
+++ b/src/pages/Alchemy.jsx
@@ -1,0 +1,56 @@
+import { useState } from 'react'
+import { StateButton } from 'ygdrassil'
+
+const potions = {
+  'Health Potion': ['Blue Mountain Flower', 'Wheat'],
+  'Fortify Smithing': ['Blisterwort', 'Spriggan Sap'],
+  Invisibility: ['Chaurus Eggs', 'Nirnroot'],
+}
+
+const allIngredients = Array.from(new Set(Object.values(potions).flat()))
+
+export default function Alchemy() {
+  const [selected, setSelected] = useState([])
+
+  const toggle = (ingredient) => {
+    setSelected((prev) =>
+      prev.includes(ingredient)
+        ? prev.filter((i) => i !== ingredient)
+        : [...prev, ingredient],
+    )
+  }
+
+  const matches = Object.entries(potions)
+    .filter(([, ingredients]) => ingredients.every((i) => selected.includes(i)))
+    .map(([name]) => name)
+
+  return (
+    <div className="alchemy">
+      <h2>Alchemy Calculator</h2>
+      <div className="ingredients">
+        {allIngredients.map((ing) => (
+          <label key={ing}>
+            <input
+              type="checkbox"
+              checked={selected.includes(ing)}
+              onChange={() => toggle(ing)}
+            />{' '}
+            {ing}
+          </label>
+        ))}
+      </div>
+      <div className="results">
+        {matches.length ? (
+          <ul>
+            {matches.map((p) => (
+              <li key={p}>{p}</li>
+            ))}
+          </ul>
+        ) : (
+          <p>No matching potions</p>
+        )}
+      </div>
+      <StateButton to="landing">Back</StateButton>
+    </div>
+  )
+}

--- a/src/pages/Landing.jsx
+++ b/src/pages/Landing.jsx
@@ -1,0 +1,13 @@
+import { StateButton } from 'ygdrassil'
+
+export default function Landing() {
+  return (
+    <div className="landing">
+      <h1>Skyrim Tools</h1>
+      <div className="menu">
+        <StateButton to="alchemy">Alchemy Calculator</StateButton>
+        <StateButton to="smithing">Smithing Calculator</StateButton>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/Smithing.jsx
+++ b/src/pages/Smithing.jsx
@@ -1,0 +1,55 @@
+import { useState } from 'react'
+import { StateButton } from 'ygdrassil'
+
+const items = {
+  'Iron Sword': {
+    materials: { 'Iron Ingot': 1, 'Leather Strips': 1 },
+    mod: 'No improvements',
+  },
+  'Steel Armor': {
+    materials: {
+      'Steel Ingot': 5,
+      'Iron Ingot': 1,
+      'Leather Strips': 3,
+    },
+    mod: 'Improved with Corundum Ingot',
+  },
+  'Dwarven Bow': {
+    materials: {
+      'Dwarven Metal Ingot': 3,
+      'Iron Ingot': 2,
+      'Leather Strips': 2,
+    },
+    mod: 'Requires Dwarven Smithing perk',
+  },
+}
+
+export default function Smithing() {
+  const [item, setItem] = useState('Iron Sword')
+  const current = items[item]
+
+  return (
+    <div className="smithing">
+      <h2>Smithing Calculator</h2>
+      <select value={item} onChange={(e) => setItem(e.target.value)}>
+        {Object.keys(items).map((name) => (
+          <option key={name} value={name}>
+            {name}
+          </option>
+        ))}
+      </select>
+      <div className="materials">
+        <h3>Materials</h3>
+        <ul>
+          {Object.entries(current.materials).map(([mat, qty]) => (
+            <li key={mat}>
+              {mat}: {qty}
+            </li>
+          ))}
+        </ul>
+        {current.mod && <p>{current.mod}</p>}
+      </div>
+      <StateButton to="landing">Back</StateButton>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Use Ygdrassil's StateMachine to create landing, alchemy, and smithing pages
- Implement alchemy calculator that lists potions matching selected ingredients
- Implement smithing calculator showing materials for selected gear

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5e9f467fc8327a9cfa212e8e49093