### PR TITLE
Add ingredient and effect based alchemy calculator

### DIFF
--- a/assets/alchemy_ingredients.json
+++ b/assets/alchemy_ingredients.json
@@ -1,0 +1,557 @@
+[
+  {
+    "﻿Ingredient": "Abecean Longfin",
+    "id": "1",
+    "weight": "0.5"
+  },
+  {
+    "﻿Ingredient": "Ancestor Moth Wing*",
+    "id": "2",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Ash Creep Cluster",
+    "id": "3",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Ash Hopper Jelly",
+    "id": "4",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Ashen Grass Pod",
+    "id": "5",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Bear Claws",
+    "id": "6",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Bee",
+    "id": "7",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Beehive Husk",
+    "id": "8",
+    "weight": "1"
+  },
+  {
+    "﻿Ingredient": "Berit's Ashes(identical to Bone Meal)",
+    "id": "9",
+    "weight": "0.5"
+  },
+  {
+    "﻿Ingredient": "Bleeding Crown",
+    "id": "10",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Blisterwort",
+    "id": "11",
+    "weight": "0.2"
+  },
+  {
+    "﻿Ingredient": "Blue Butterfly Wing",
+    "id": "12",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Blue Dartwing",
+    "id": "13",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Blue Mountain Flower",
+    "id": "14",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Boar Tusk",
+    "id": "15",
+    "weight": "0.5"
+  },
+  {
+    "﻿Ingredient": "Bone Meal",
+    "id": "16",
+    "weight": "0.5"
+  },
+  {
+    "﻿Ingredient": "Briar Heart",
+    "id": "17",
+    "weight": "0.5"
+  },
+  {
+    "﻿Ingredient": "Burnt Spriggan Wood",
+    "id": "18",
+    "weight": "0.5"
+  },
+  {
+    "﻿Ingredient": "Butterfly Wing",
+    "id": "19",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Canis Root",
+    "id": "20",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Charred Skeever Hide",
+    "id": "21",
+    "weight": "0.5"
+  },
+  {
+    "﻿Ingredient": "Chaurus Eggs",
+    "id": "22",
+    "weight": "0.2"
+  },
+  {
+    "﻿Ingredient": "Chaurus Hunter Antennae*",
+    "id": "23",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Chicken's Egg",
+    "id": "24",
+    "weight": "0.5"
+  },
+  {
+    "﻿Ingredient": "Creep Cluster",
+    "id": "25",
+    "weight": "0.2"
+  },
+  {
+    "﻿Ingredient": "Crimson Nirnroot",
+    "id": "26",
+    "weight": "0.2"
+  },
+  {
+    "﻿Ingredient": "Cyrodilic Spadetail",
+    "id": "27",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Daedra Heart",
+    "id": "28",
+    "weight": "0.5"
+  },
+  {
+    "﻿Ingredient": "Deathbell",
+    "id": "29",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Dragon's Tongue",
+    "id": "30",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Dwarven Oil",
+    "id": "31",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Ectoplasm",
+    "id": "32",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Elves Ear",
+    "id": "33",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Emperor Parasol Moss",
+    "id": "34",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Eye of Sabre Cat",
+    "id": "35",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Falmer Ear",
+    "id": "36",
+    "weight": "0.2"
+  },
+  {
+    "﻿Ingredient": "Felsaad Tern Feathers",
+    "id": "37",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Fire Salts",
+    "id": "38",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Fly Amanita",
+    "id": "39",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Frost Mirriam",
+    "id": "40",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Frost Salts",
+    "id": "41",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Garlic",
+    "id": "42",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Giant Lichen",
+    "id": "43",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Giant's Toe",
+    "id": "44",
+    "weight": "1"
+  },
+  {
+    "﻿Ingredient": "Gleamblossom*",
+    "id": "45",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Glow Dust",
+    "id": "46",
+    "weight": "0.5"
+  },
+  {
+    "﻿Ingredient": "Glowing Mushroom",
+    "id": "47",
+    "weight": "0.2"
+  },
+  {
+    "﻿Ingredient": "Grass Pod",
+    "id": "48",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Hagraven Claw",
+    "id": "49",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Hagraven Feathers",
+    "id": "50",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Hanging Moss",
+    "id": "51",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Hawk Beak",
+    "id": "52",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Hawk Feathers",
+    "id": "53",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Hawk's Eggâ€ ",
+    "id": "54",
+    "weight": "0.5"
+  },
+  {
+    "﻿Ingredient": "Histcarp",
+    "id": "55",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Honeycomb",
+    "id": "56",
+    "weight": "1"
+  },
+  {
+    "﻿Ingredient": "Human Flesh",
+    "id": "57",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Human Heart",
+    "id": "58",
+    "weight": "1"
+  },
+  {
+    "﻿Ingredient": "Ice Wraith Teeth",
+    "id": "59",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Imp Stool",
+    "id": "60",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Jarrin Root",
+    "id": "61",
+    "weight": "0.5"
+  },
+  {
+    "﻿Ingredient": "Jazbay Grapes",
+    "id": "62",
+    "weight": "0.2"
+  },
+  {
+    "﻿Ingredient": "Juniper Berries",
+    "id": "63",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Large Antlers",
+    "id": "64",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Lavender",
+    "id": "65",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Luna Moth Wing",
+    "id": "66",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Moon Sugar",
+    "id": "67",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Mora Tapinella",
+    "id": "68",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Mudcrab Chitin",
+    "id": "69",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Namira's Rot",
+    "id": "70",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Netch Jelly",
+    "id": "71",
+    "weight": "0.5"
+  },
+  {
+    "﻿Ingredient": "Nightshade",
+    "id": "72",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Nirnroot",
+    "id": "73",
+    "weight": "0.2"
+  },
+  {
+    "﻿Ingredient": "Nordic Barnacle",
+    "id": "74",
+    "weight": "0.2"
+  },
+  {
+    "﻿Ingredient": "Orange Dartwing",
+    "id": "75",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Pearl",
+    "id": "76",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Pine Thrush Egg",
+    "id": "77",
+    "weight": "0.5"
+  },
+  {
+    "﻿Ingredient": "Poison Bloom*",
+    "id": "78",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Powdered Mammoth Tusk",
+    "id": "79",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Purple Mountain Flower",
+    "id": "80",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Red Mountain Flower",
+    "id": "81",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "River Betty",
+    "id": "82",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Rock Warbler Egg",
+    "id": "83",
+    "weight": "0.5"
+  },
+  {
+    "﻿Ingredient": "Sabre Cat Tooth",
+    "id": "84",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Salmon Roeâ€ ",
+    "id": "85",
+    "weight": "0.2"
+  },
+  {
+    "﻿Ingredient": "Salt Pile",
+    "id": "86",
+    "weight": "0.2"
+  },
+  {
+    "﻿Ingredient": "Scaly Pholiota",
+    "id": "87",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Scathecraw",
+    "id": "88",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Silverside Perch",
+    "id": "89",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Skeever Tail",
+    "id": "90",
+    "weight": "0.2"
+  },
+  {
+    "﻿Ingredient": "Slaughterfish Egg",
+    "id": "91",
+    "weight": "0.2"
+  },
+  {
+    "﻿Ingredient": "Slaughterfish Scales",
+    "id": "92",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Small Antlers",
+    "id": "93",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Small Pearl",
+    "id": "94",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Snowberries",
+    "id": "95",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Spawn Ash",
+    "id": "96",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Spider Egg",
+    "id": "97",
+    "weight": "0.2"
+  },
+  {
+    "﻿Ingredient": "Spriggan Sap",
+    "id": "98",
+    "weight": "0.2"
+  },
+  {
+    "﻿Ingredient": "Swamp Fungal Pod",
+    "id": "99",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Taproot",
+    "id": "100",
+    "weight": "0.5"
+  },
+  {
+    "﻿Ingredient": "Thistle Branch",
+    "id": "101",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Torchbug Thorax",
+    "id": "102",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Trama Root",
+    "id": "103",
+    "weight": "0.2"
+  },
+  {
+    "﻿Ingredient": "Troll Fat",
+    "id": "104",
+    "weight": "1"
+  },
+  {
+    "﻿Ingredient": "Tundra Cotton",
+    "id": "105",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Vampire Dust",
+    "id": "106",
+    "weight": "0.2"
+  },
+  {
+    "﻿Ingredient": "Void Salts",
+    "id": "107",
+    "weight": "0.2"
+  },
+  {
+    "﻿Ingredient": "Wheat",
+    "id": "108",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "White Cap",
+    "id": "109",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Wisp Wrappings",
+    "id": "110",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Yellow Mountain Flower*",
+    "id": "111",
+    "weight": "0.1"
+  }
+]

--- a/assets/csv2json.js
+++ b/assets/csv2json.js
@@ -1,6 +1,8 @@
+/* eslint-env node */
 // csv-to-json.mjs
 import fs from 'fs';
 import { createRequire } from 'module';
+import process from "node:process";
 const require = createRequire(import.meta.url);
 const csv = require('csv-parser');
 

--- a/src/assets/alchemy_effects.json
+++ b/src/assets/alchemy_effects.json
@@ -1,0 +1,222 @@
+[
+  {
+    "﻿name": "Cure Disease",
+    "id": "1"
+  },
+  {
+    "﻿name": "Damage Health",
+    "id": "2"
+  },
+  {
+    "﻿name": "Damage Magicka",
+    "id": "3"
+  },
+  {
+    "﻿name": "Damage Magicka Regen",
+    "id": "4"
+  },
+  {
+    "﻿name": "Damage Stamina",
+    "id": "5"
+  },
+  {
+    "﻿name": "Damage Stamina Regen",
+    "id": "6"
+  },
+  {
+    "﻿name": "Fear",
+    "id": "7"
+  },
+  {
+    "﻿name": "Fortify Alteration",
+    "id": "8"
+  },
+  {
+    "﻿name": "Fortify Barter",
+    "id": "9"
+  },
+  {
+    "﻿name": "Fortify Block",
+    "id": "10"
+  },
+  {
+    "﻿name": "Fortify Carry Weight",
+    "id": "11"
+  },
+  {
+    "﻿name": "Fortify Conjuration",
+    "id": "12"
+  },
+  {
+    "﻿name": "Fortify Destruction",
+    "id": "13"
+  },
+  {
+    "﻿name": "Fortify Enchanting",
+    "id": "14"
+  },
+  {
+    "﻿name": "Fortify Health",
+    "id": "15"
+  },
+  {
+    "﻿name": "Fortify Heavy Armor",
+    "id": "16"
+  },
+  {
+    "﻿name": "Fortify Illusion",
+    "id": "17"
+  },
+  {
+    "﻿name": "Fortify Light Armor",
+    "id": "18"
+  },
+  {
+    "﻿name": "Fortify Lockpicking",
+    "id": "19"
+  },
+  {
+    "﻿name": "Fortify Magicka",
+    "id": "20"
+  },
+  {
+    "﻿name": "Fortify Marksman",
+    "id": "21"
+  },
+  {
+    "﻿name": "Fortify One-Handed",
+    "id": "22"
+  },
+  {
+    "﻿name": "Fortify Pickpocket",
+    "id": "23"
+  },
+  {
+    "﻿name": "Fortify Restoration",
+    "id": "24"
+  },
+  {
+    "﻿name": "Fortify Smithing",
+    "id": "25"
+  },
+  {
+    "﻿name": "Fortify Sneak",
+    "id": "26"
+  },
+  {
+    "﻿name": "Fortify Stamina",
+    "id": "27"
+  },
+  {
+    "﻿name": "Fortify Two-Handed",
+    "id": "28"
+  },
+  {
+    "﻿name": "Frenzy",
+    "id": "29"
+  },
+  {
+    "﻿name": "Invisibility",
+    "id": "30"
+  },
+  {
+    "﻿name": "Lingering Damage Health",
+    "id": "31"
+  },
+  {
+    "﻿name": "Lingering Damage Magicka",
+    "id": "32"
+  },
+  {
+    "﻿name": "Lingering Damage Stamina",
+    "id": "33"
+  },
+  {
+    "﻿name": "Paralysis",
+    "id": "34"
+  },
+  {
+    "﻿name": "Ravage Health",
+    "id": "35"
+  },
+  {
+    "﻿name": "Ravage Magicka",
+    "id": "36"
+  },
+  {
+    "﻿name": "Ravage Stamina",
+    "id": "37"
+  },
+  {
+    "﻿name": "Regenerate Health",
+    "id": "38"
+  },
+  {
+    "﻿name": "Regenerate Magicka",
+    "id": "39"
+  },
+  {
+    "﻿name": "Regenerate Stamina",
+    "id": "40"
+  },
+  {
+    "﻿name": "Resist Fire",
+    "id": "41"
+  },
+  {
+    "﻿name": "Resist Frost",
+    "id": "42"
+  },
+  {
+    "﻿name": "Resist Magic",
+    "id": "43"
+  },
+  {
+    "﻿name": "Resist Poison",
+    "id": "44"
+  },
+  {
+    "﻿name": "Resist Shock",
+    "id": "45"
+  },
+  {
+    "﻿name": "Restore Health",
+    "id": "46"
+  },
+  {
+    "﻿name": "Restore Magicka",
+    "id": "47"
+  },
+  {
+    "﻿name": "Restore Stamina",
+    "id": "48"
+  },
+  {
+    "﻿name": "Slow",
+    "id": "49"
+  },
+  {
+    "﻿name": "Waterbreathing",
+    "id": "50"
+  },
+  {
+    "﻿name": "Weakness to Fire",
+    "id": "51"
+  },
+  {
+    "﻿name": "Weakness to Frost",
+    "id": "52"
+  },
+  {
+    "﻿name": "Weakness to Magic",
+    "id": "53"
+  },
+  {
+    "﻿name": "Weakness to Poison",
+    "id": "54"
+  },
+  {
+    "﻿name": "Weakness to Shock",
+    "id": "55"
+  }
+]

--- a/src/assets/alchemy_ingredient_effects.json
+++ b/src/assets/alchemy_ingredient_effects.json
@@ -1,0 +1,1778 @@
+[
+  {
+    "﻿ingredient_id": "1",
+    "effect_id": "52"
+  },
+  {
+    "﻿ingredient_id": "1",
+    "effect_id": "26"
+  },
+  {
+    "﻿ingredient_id": "1",
+    "effect_id": "54"
+  },
+  {
+    "﻿ingredient_id": "1",
+    "effect_id": "24"
+  },
+  {
+    "﻿ingredient_id": "2",
+    "effect_id": "5"
+  },
+  {
+    "﻿ingredient_id": "2",
+    "effect_id": "12"
+  },
+  {
+    "﻿ingredient_id": "2",
+    "effect_id": "4"
+  },
+  {
+    "﻿ingredient_id": "2",
+    "effect_id": "14"
+  },
+  {
+    "﻿ingredient_id": "3",
+    "effect_id": "5"
+  },
+  {
+    "﻿ingredient_id": "3",
+    "effect_id": "30"
+  },
+  {
+    "﻿ingredient_id": "3",
+    "effect_id": "41"
+  },
+  {
+    "﻿ingredient_id": "3",
+    "effect_id": "13"
+  },
+  {
+    "﻿ingredient_id": "4",
+    "effect_id": "46"
+  },
+  {
+    "﻿ingredient_id": "4",
+    "effect_id": "18"
+  },
+  {
+    "﻿ingredient_id": "4",
+    "effect_id": "45"
+  },
+  {
+    "﻿ingredient_id": "4",
+    "effect_id": "52"
+  },
+  {
+    "﻿ingredient_id": "5",
+    "effect_id": "41"
+  },
+  {
+    "﻿ingredient_id": "5",
+    "effect_id": "55"
+  },
+  {
+    "﻿ingredient_id": "5",
+    "effect_id": "19"
+  },
+  {
+    "﻿ingredient_id": "5",
+    "effect_id": "26"
+  },
+  {
+    "﻿ingredient_id": "6",
+    "effect_id": "48"
+  },
+  {
+    "﻿ingredient_id": "6",
+    "effect_id": "15"
+  },
+  {
+    "﻿ingredient_id": "6",
+    "effect_id": "22"
+  },
+  {
+    "﻿ingredient_id": "6",
+    "effect_id": "4"
+  },
+  {
+    "﻿ingredient_id": "7",
+    "effect_id": "48"
+  },
+  {
+    "﻿ingredient_id": "7",
+    "effect_id": "37"
+  },
+  {
+    "﻿ingredient_id": "7",
+    "effect_id": "40"
+  },
+  {
+    "﻿ingredient_id": "7",
+    "effect_id": "55"
+  },
+  {
+    "﻿ingredient_id": "8",
+    "effect_id": "44"
+  },
+  {
+    "﻿ingredient_id": "8",
+    "effect_id": "18"
+  },
+  {
+    "﻿ingredient_id": "8",
+    "effect_id": "26"
+  },
+  {
+    "﻿ingredient_id": "8",
+    "effect_id": "13"
+  },
+  {
+    "﻿ingredient_id": "9",
+    "effect_id": "5"
+  },
+  {
+    "﻿ingredient_id": "9",
+    "effect_id": "41"
+  },
+  {
+    "﻿ingredient_id": "9",
+    "effect_id": "12"
+  },
+  {
+    "﻿ingredient_id": "9",
+    "effect_id": "37"
+  },
+  {
+    "﻿ingredient_id": "10",
+    "effect_id": "51"
+  },
+  {
+    "﻿ingredient_id": "10",
+    "effect_id": "10"
+  },
+  {
+    "﻿ingredient_id": "10",
+    "effect_id": "54"
+  },
+  {
+    "﻿ingredient_id": "10",
+    "effect_id": "43"
+  },
+  {
+    "﻿ingredient_id": "11",
+    "effect_id": "5"
+  },
+  {
+    "﻿ingredient_id": "11",
+    "effect_id": "29"
+  },
+  {
+    "﻿ingredient_id": "11",
+    "effect_id": "46"
+  },
+  {
+    "﻿ingredient_id": "11",
+    "effect_id": "25"
+  },
+  {
+    "﻿ingredient_id": "12",
+    "effect_id": "5"
+  },
+  {
+    "﻿ingredient_id": "12",
+    "effect_id": "12"
+  },
+  {
+    "﻿ingredient_id": "12",
+    "effect_id": "4"
+  },
+  {
+    "﻿ingredient_id": "12",
+    "effect_id": "14"
+  },
+  {
+    "﻿ingredient_id": "13",
+    "effect_id": "45"
+  },
+  {
+    "﻿ingredient_id": "13",
+    "effect_id": "23"
+  },
+  {
+    "﻿ingredient_id": "13",
+    "effect_id": "46"
+  },
+  {
+    "﻿ingredient_id": "13",
+    "effect_id": "7"
+  },
+  {
+    "﻿ingredient_id": "14",
+    "effect_id": "46"
+  },
+  {
+    "﻿ingredient_id": "14",
+    "effect_id": "12"
+  },
+  {
+    "﻿ingredient_id": "14",
+    "effect_id": "15"
+  },
+  {
+    "﻿ingredient_id": "14",
+    "effect_id": "4"
+  },
+  {
+    "﻿ingredient_id": "15",
+    "effect_id": "27"
+  },
+  {
+    "﻿ingredient_id": "15",
+    "effect_id": "15"
+  },
+  {
+    "﻿ingredient_id": "15",
+    "effect_id": "10"
+  },
+  {
+    "﻿ingredient_id": "15",
+    "effect_id": "29"
+  },
+  {
+    "﻿ingredient_id": "16",
+    "effect_id": "5"
+  },
+  {
+    "﻿ingredient_id": "16",
+    "effect_id": "41"
+  },
+  {
+    "﻿ingredient_id": "16",
+    "effect_id": "12"
+  },
+  {
+    "﻿ingredient_id": "16",
+    "effect_id": "37"
+  },
+  {
+    "﻿ingredient_id": "17",
+    "effect_id": "47"
+  },
+  {
+    "﻿ingredient_id": "17",
+    "effect_id": "10"
+  },
+  {
+    "﻿ingredient_id": "17",
+    "effect_id": "34"
+  },
+  {
+    "﻿ingredient_id": "17",
+    "effect_id": "20"
+  },
+  {
+    "﻿ingredient_id": "18",
+    "effect_id": "51"
+  },
+  {
+    "﻿ingredient_id": "18",
+    "effect_id": "8"
+  },
+  {
+    "﻿ingredient_id": "18",
+    "effect_id": "4"
+  },
+  {
+    "﻿ingredient_id": "18",
+    "effect_id": "49"
+  },
+  {
+    "﻿ingredient_id": "19",
+    "effect_id": "46"
+  },
+  {
+    "﻿ingredient_id": "19",
+    "effect_id": "9"
+  },
+  {
+    "﻿ingredient_id": "19",
+    "effect_id": "33"
+  },
+  {
+    "﻿ingredient_id": "19",
+    "effect_id": "3"
+  },
+  {
+    "﻿ingredient_id": "20",
+    "effect_id": "5"
+  },
+  {
+    "﻿ingredient_id": "20",
+    "effect_id": "22"
+  },
+  {
+    "﻿ingredient_id": "20",
+    "effect_id": "21"
+  },
+  {
+    "﻿ingredient_id": "20",
+    "effect_id": "34"
+  },
+  {
+    "﻿ingredient_id": "21",
+    "effect_id": "48"
+  },
+  {
+    "﻿ingredient_id": "21",
+    "effect_id": "1"
+  },
+  {
+    "﻿ingredient_id": "21",
+    "effect_id": "44"
+  },
+  {
+    "﻿ingredient_id": "21",
+    "effect_id": "46"
+  },
+  {
+    "﻿ingredient_id": "22",
+    "effect_id": "54"
+  },
+  {
+    "﻿ingredient_id": "22",
+    "effect_id": "27"
+  },
+  {
+    "﻿ingredient_id": "22",
+    "effect_id": "3"
+  },
+  {
+    "﻿ingredient_id": "22",
+    "effect_id": "30"
+  },
+  {
+    "﻿ingredient_id": "23",
+    "effect_id": "5"
+  },
+  {
+    "﻿ingredient_id": "23",
+    "effect_id": "12"
+  },
+  {
+    "﻿ingredient_id": "23",
+    "effect_id": "4"
+  },
+  {
+    "﻿ingredient_id": "23",
+    "effect_id": "14"
+  },
+  {
+    "﻿ingredient_id": "24",
+    "effect_id": "43"
+  },
+  {
+    "﻿ingredient_id": "24",
+    "effect_id": "4"
+  },
+  {
+    "﻿ingredient_id": "24",
+    "effect_id": "50"
+  },
+  {
+    "﻿ingredient_id": "24",
+    "effect_id": "33"
+  },
+  {
+    "﻿ingredient_id": "25",
+    "effect_id": "47"
+  },
+  {
+    "﻿ingredient_id": "25",
+    "effect_id": "6"
+  },
+  {
+    "﻿ingredient_id": "25",
+    "effect_id": "11"
+  },
+  {
+    "﻿ingredient_id": "25",
+    "effect_id": "53"
+  },
+  {
+    "﻿ingredient_id": "26",
+    "effect_id": "2"
+  },
+  {
+    "﻿ingredient_id": "26",
+    "effect_id": "5"
+  },
+  {
+    "﻿ingredient_id": "26",
+    "effect_id": "30"
+  },
+  {
+    "﻿ingredient_id": "26",
+    "effect_id": "43"
+  },
+  {
+    "﻿ingredient_id": "27",
+    "effect_id": "5"
+  },
+  {
+    "﻿ingredient_id": "27",
+    "effect_id": "24"
+  },
+  {
+    "﻿ingredient_id": "27",
+    "effect_id": "7"
+  },
+  {
+    "﻿ingredient_id": "27",
+    "effect_id": "35"
+  },
+  {
+    "﻿ingredient_id": "28",
+    "effect_id": "46"
+  },
+  {
+    "﻿ingredient_id": "28",
+    "effect_id": "6"
+  },
+  {
+    "﻿ingredient_id": "28",
+    "effect_id": "3"
+  },
+  {
+    "﻿ingredient_id": "28",
+    "effect_id": "7"
+  },
+  {
+    "﻿ingredient_id": "29",
+    "effect_id": "2"
+  },
+  {
+    "﻿ingredient_id": "29",
+    "effect_id": "37"
+  },
+  {
+    "﻿ingredient_id": "29",
+    "effect_id": "49"
+  },
+  {
+    "﻿ingredient_id": "29",
+    "effect_id": "54"
+  },
+  {
+    "﻿ingredient_id": "30",
+    "effect_id": "41"
+  },
+  {
+    "﻿ingredient_id": "30",
+    "effect_id": "9"
+  },
+  {
+    "﻿ingredient_id": "30",
+    "effect_id": "17"
+  },
+  {
+    "﻿ingredient_id": "30",
+    "effect_id": "28"
+  },
+  {
+    "﻿ingredient_id": "31",
+    "effect_id": "53"
+  },
+  {
+    "﻿ingredient_id": "31",
+    "effect_id": "17"
+  },
+  {
+    "﻿ingredient_id": "31",
+    "effect_id": "39"
+  },
+  {
+    "﻿ingredient_id": "31",
+    "effect_id": "47"
+  },
+  {
+    "﻿ingredient_id": "32",
+    "effect_id": "47"
+  },
+  {
+    "﻿ingredient_id": "32",
+    "effect_id": "13"
+  },
+  {
+    "﻿ingredient_id": "32",
+    "effect_id": "20"
+  },
+  {
+    "﻿ingredient_id": "32",
+    "effect_id": "2"
+  },
+  {
+    "﻿ingredient_id": "33",
+    "effect_id": "47"
+  },
+  {
+    "﻿ingredient_id": "33",
+    "effect_id": "21"
+  },
+  {
+    "﻿ingredient_id": "33",
+    "effect_id": "52"
+  },
+  {
+    "﻿ingredient_id": "33",
+    "effect_id": "41"
+  },
+  {
+    "﻿ingredient_id": "34",
+    "effect_id": "2"
+  },
+  {
+    "﻿ingredient_id": "34",
+    "effect_id": "20"
+  },
+  {
+    "﻿ingredient_id": "34",
+    "effect_id": "38"
+  },
+  {
+    "﻿ingredient_id": "34",
+    "effect_id": "28"
+  },
+  {
+    "﻿ingredient_id": "35",
+    "effect_id": "48"
+  },
+  {
+    "﻿ingredient_id": "35",
+    "effect_id": "35"
+  },
+  {
+    "﻿ingredient_id": "35",
+    "effect_id": "3"
+  },
+  {
+    "﻿ingredient_id": "35",
+    "effect_id": "46"
+  },
+  {
+    "﻿ingredient_id": "36",
+    "effect_id": "2"
+  },
+  {
+    "﻿ingredient_id": "36",
+    "effect_id": "29"
+  },
+  {
+    "﻿ingredient_id": "36",
+    "effect_id": "44"
+  },
+  {
+    "﻿ingredient_id": "36",
+    "effect_id": "19"
+  },
+  {
+    "﻿ingredient_id": "37",
+    "effect_id": "46"
+  },
+  {
+    "﻿ingredient_id": "37",
+    "effect_id": "18"
+  },
+  {
+    "﻿ingredient_id": "37",
+    "effect_id": "1"
+  },
+  {
+    "﻿ingredient_id": "37",
+    "effect_id": "43"
+  },
+  {
+    "﻿ingredient_id": "38",
+    "effect_id": "52"
+  },
+  {
+    "﻿ingredient_id": "38",
+    "effect_id": "41"
+  },
+  {
+    "﻿ingredient_id": "38",
+    "effect_id": "47"
+  },
+  {
+    "﻿ingredient_id": "38",
+    "effect_id": "39"
+  },
+  {
+    "﻿ingredient_id": "39",
+    "effect_id": "41"
+  },
+  {
+    "﻿ingredient_id": "39",
+    "effect_id": "28"
+  },
+  {
+    "﻿ingredient_id": "39",
+    "effect_id": "29"
+  },
+  {
+    "﻿ingredient_id": "39",
+    "effect_id": "40"
+  },
+  {
+    "﻿ingredient_id": "40",
+    "effect_id": "42"
+  },
+  {
+    "﻿ingredient_id": "40",
+    "effect_id": "26"
+  },
+  {
+    "﻿ingredient_id": "40",
+    "effect_id": "36"
+  },
+  {
+    "﻿ingredient_id": "40",
+    "effect_id": "6"
+  },
+  {
+    "﻿ingredient_id": "41",
+    "effect_id": "51"
+  },
+  {
+    "﻿ingredient_id": "41",
+    "effect_id": "42"
+  },
+  {
+    "﻿ingredient_id": "41",
+    "effect_id": "47"
+  },
+  {
+    "﻿ingredient_id": "41",
+    "effect_id": "12"
+  },
+  {
+    "﻿ingredient_id": "42",
+    "effect_id": "44"
+  },
+  {
+    "﻿ingredient_id": "42",
+    "effect_id": "27"
+  },
+  {
+    "﻿ingredient_id": "42",
+    "effect_id": "39"
+  },
+  {
+    "﻿ingredient_id": "42",
+    "effect_id": "38"
+  },
+  {
+    "﻿ingredient_id": "43",
+    "effect_id": "55"
+  },
+  {
+    "﻿ingredient_id": "43",
+    "effect_id": "35"
+  },
+  {
+    "﻿ingredient_id": "43",
+    "effect_id": "54"
+  },
+  {
+    "﻿ingredient_id": "43",
+    "effect_id": "47"
+  },
+  {
+    "﻿ingredient_id": "44",
+    "effect_id": "5"
+  },
+  {
+    "﻿ingredient_id": "44",
+    "effect_id": "15"
+  },
+  {
+    "﻿ingredient_id": "44",
+    "effect_id": "11"
+  },
+  {
+    "﻿ingredient_id": "44",
+    "effect_id": "6"
+  },
+  {
+    "﻿ingredient_id": "45",
+    "effect_id": "43"
+  },
+  {
+    "﻿ingredient_id": "45",
+    "effect_id": "7"
+  },
+  {
+    "﻿ingredient_id": "45",
+    "effect_id": "38"
+  },
+  {
+    "﻿ingredient_id": "45",
+    "effect_id": "34"
+  },
+  {
+    "﻿ingredient_id": "46",
+    "effect_id": "3"
+  },
+  {
+    "﻿ingredient_id": "46",
+    "effect_id": "4"
+  },
+  {
+    "﻿ingredient_id": "46",
+    "effect_id": "13"
+  },
+  {
+    "﻿ingredient_id": "46",
+    "effect_id": "45"
+  },
+  {
+    "﻿ingredient_id": "47",
+    "effect_id": "45"
+  },
+  {
+    "﻿ingredient_id": "47",
+    "effect_id": "13"
+  },
+  {
+    "﻿ingredient_id": "47",
+    "effect_id": "25"
+  },
+  {
+    "﻿ingredient_id": "47",
+    "effect_id": "15"
+  },
+  {
+    "﻿ingredient_id": "48",
+    "effect_id": "44"
+  },
+  {
+    "﻿ingredient_id": "48",
+    "effect_id": "36"
+  },
+  {
+    "﻿ingredient_id": "48",
+    "effect_id": "8"
+  },
+  {
+    "﻿ingredient_id": "48",
+    "effect_id": "47"
+  },
+  {
+    "﻿ingredient_id": "49",
+    "effect_id": "43"
+  },
+  {
+    "﻿ingredient_id": "49",
+    "effect_id": "32"
+  },
+  {
+    "﻿ingredient_id": "49",
+    "effect_id": "14"
+  },
+  {
+    "﻿ingredient_id": "49",
+    "effect_id": "9"
+  },
+  {
+    "﻿ingredient_id": "50",
+    "effect_id": "3"
+  },
+  {
+    "﻿ingredient_id": "50",
+    "effect_id": "12"
+  },
+  {
+    "﻿ingredient_id": "50",
+    "effect_id": "29"
+  },
+  {
+    "﻿ingredient_id": "50",
+    "effect_id": "55"
+  },
+  {
+    "﻿ingredient_id": "51",
+    "effect_id": "3"
+  },
+  {
+    "﻿ingredient_id": "51",
+    "effect_id": "15"
+  },
+  {
+    "﻿ingredient_id": "51",
+    "effect_id": "4"
+  },
+  {
+    "﻿ingredient_id": "51",
+    "effect_id": "22"
+  },
+  {
+    "﻿ingredient_id": "52",
+    "effect_id": "48"
+  },
+  {
+    "﻿ingredient_id": "52",
+    "effect_id": "42"
+  },
+  {
+    "﻿ingredient_id": "52",
+    "effect_id": "11"
+  },
+  {
+    "﻿ingredient_id": "52",
+    "effect_id": "45"
+  },
+  {
+    "﻿ingredient_id": "53",
+    "effect_id": "1"
+  },
+  {
+    "﻿ingredient_id": "53",
+    "effect_id": "18"
+  },
+  {
+    "﻿ingredient_id": "53",
+    "effect_id": "22"
+  },
+  {
+    "﻿ingredient_id": "53",
+    "effect_id": "26"
+  },
+  {
+    "﻿ingredient_id": "54",
+    "effect_id": "43"
+  },
+  {
+    "﻿ingredient_id": "54",
+    "effect_id": "4"
+  },
+  {
+    "﻿ingredient_id": "54",
+    "effect_id": "50"
+  },
+  {
+    "﻿ingredient_id": "54",
+    "effect_id": "33"
+  },
+  {
+    "﻿ingredient_id": "55",
+    "effect_id": "48"
+  },
+  {
+    "﻿ingredient_id": "55",
+    "effect_id": "20"
+  },
+  {
+    "﻿ingredient_id": "55",
+    "effect_id": "6"
+  },
+  {
+    "﻿ingredient_id": "55",
+    "effect_id": "50"
+  },
+  {
+    "﻿ingredient_id": "56",
+    "effect_id": "48"
+  },
+  {
+    "﻿ingredient_id": "56",
+    "effect_id": "10"
+  },
+  {
+    "﻿ingredient_id": "56",
+    "effect_id": "18"
+  },
+  {
+    "﻿ingredient_id": "56",
+    "effect_id": "37"
+  },
+  {
+    "﻿ingredient_id": "57",
+    "effect_id": "2"
+  },
+  {
+    "﻿ingredient_id": "57",
+    "effect_id": "34"
+  },
+  {
+    "﻿ingredient_id": "57",
+    "effect_id": "47"
+  },
+  {
+    "﻿ingredient_id": "57",
+    "effect_id": "26"
+  },
+  {
+    "﻿ingredient_id": "58",
+    "effect_id": "2"
+  },
+  {
+    "﻿ingredient_id": "58",
+    "effect_id": "3"
+  },
+  {
+    "﻿ingredient_id": "58",
+    "effect_id": "4"
+  },
+  {
+    "﻿ingredient_id": "58",
+    "effect_id": "29"
+  },
+  {
+    "﻿ingredient_id": "59",
+    "effect_id": "52"
+  },
+  {
+    "﻿ingredient_id": "59",
+    "effect_id": "16"
+  },
+  {
+    "﻿ingredient_id": "59",
+    "effect_id": "30"
+  },
+  {
+    "﻿ingredient_id": "59",
+    "effect_id": "51"
+  },
+  {
+    "﻿ingredient_id": "60",
+    "effect_id": "2"
+  },
+  {
+    "﻿ingredient_id": "60",
+    "effect_id": "31"
+  },
+  {
+    "﻿ingredient_id": "60",
+    "effect_id": "34"
+  },
+  {
+    "﻿ingredient_id": "60",
+    "effect_id": "46"
+  },
+  {
+    "﻿ingredient_id": "61",
+    "effect_id": "2"
+  },
+  {
+    "﻿ingredient_id": "61",
+    "effect_id": "3"
+  },
+  {
+    "﻿ingredient_id": "61",
+    "effect_id": "5"
+  },
+  {
+    "﻿ingredient_id": "61",
+    "effect_id": "4"
+  },
+  {
+    "﻿ingredient_id": "62",
+    "effect_id": "53"
+  },
+  {
+    "﻿ingredient_id": "62",
+    "effect_id": "20"
+  },
+  {
+    "﻿ingredient_id": "62",
+    "effect_id": "39"
+  },
+  {
+    "﻿ingredient_id": "62",
+    "effect_id": "35"
+  },
+  {
+    "﻿ingredient_id": "63",
+    "effect_id": "51"
+  },
+  {
+    "﻿ingredient_id": "63",
+    "effect_id": "21"
+  },
+  {
+    "﻿ingredient_id": "63",
+    "effect_id": "38"
+  },
+  {
+    "﻿ingredient_id": "63",
+    "effect_id": "6"
+  },
+  {
+    "﻿ingredient_id": "64",
+    "effect_id": "48"
+  },
+  {
+    "﻿ingredient_id": "64",
+    "effect_id": "27"
+  },
+  {
+    "﻿ingredient_id": "64",
+    "effect_id": "49"
+  },
+  {
+    "﻿ingredient_id": "64",
+    "effect_id": "6"
+  },
+  {
+    "﻿ingredient_id": "65",
+    "effect_id": "43"
+  },
+  {
+    "﻿ingredient_id": "65",
+    "effect_id": "27"
+  },
+  {
+    "﻿ingredient_id": "65",
+    "effect_id": "36"
+  },
+  {
+    "﻿ingredient_id": "65",
+    "effect_id": "12"
+  },
+  {
+    "﻿ingredient_id": "66",
+    "effect_id": "3"
+  },
+  {
+    "﻿ingredient_id": "66",
+    "effect_id": "18"
+  },
+  {
+    "﻿ingredient_id": "66",
+    "effect_id": "38"
+  },
+  {
+    "﻿ingredient_id": "66",
+    "effect_id": "30"
+  },
+  {
+    "﻿ingredient_id": "67",
+    "effect_id": "51"
+  },
+  {
+    "﻿ingredient_id": "67",
+    "effect_id": "42"
+  },
+  {
+    "﻿ingredient_id": "67",
+    "effect_id": "47"
+  },
+  {
+    "﻿ingredient_id": "67",
+    "effect_id": "39"
+  },
+  {
+    "﻿ingredient_id": "68",
+    "effect_id": "47"
+  },
+  {
+    "﻿ingredient_id": "68",
+    "effect_id": "31"
+  },
+  {
+    "﻿ingredient_id": "68",
+    "effect_id": "40"
+  },
+  {
+    "﻿ingredient_id": "68",
+    "effect_id": "17"
+  },
+  {
+    "﻿ingredient_id": "69",
+    "effect_id": "48"
+  },
+  {
+    "﻿ingredient_id": "69",
+    "effect_id": "1"
+  },
+  {
+    "﻿ingredient_id": "69",
+    "effect_id": "44"
+  },
+  {
+    "﻿ingredient_id": "69",
+    "effect_id": "41"
+  },
+  {
+    "﻿ingredient_id": "70",
+    "effect_id": "3"
+  },
+  {
+    "﻿ingredient_id": "70",
+    "effect_id": "19"
+  },
+  {
+    "﻿ingredient_id": "70",
+    "effect_id": "7"
+  },
+  {
+    "﻿ingredient_id": "70",
+    "effect_id": "38"
+  },
+  {
+    "﻿ingredient_id": "71",
+    "effect_id": "34"
+  },
+  {
+    "﻿ingredient_id": "71",
+    "effect_id": "11"
+  },
+  {
+    "﻿ingredient_id": "71",
+    "effect_id": "48"
+  },
+  {
+    "﻿ingredient_id": "71",
+    "effect_id": "7"
+  },
+  {
+    "﻿ingredient_id": "72",
+    "effect_id": "2"
+  },
+  {
+    "﻿ingredient_id": "72",
+    "effect_id": "4"
+  },
+  {
+    "﻿ingredient_id": "72",
+    "effect_id": "33"
+  },
+  {
+    "﻿ingredient_id": "72",
+    "effect_id": "13"
+  },
+  {
+    "﻿ingredient_id": "73",
+    "effect_id": "2"
+  },
+  {
+    "﻿ingredient_id": "73",
+    "effect_id": "5"
+  },
+  {
+    "﻿ingredient_id": "73",
+    "effect_id": "30"
+  },
+  {
+    "﻿ingredient_id": "73",
+    "effect_id": "43"
+  },
+  {
+    "﻿ingredient_id": "74",
+    "effect_id": "3"
+  },
+  {
+    "﻿ingredient_id": "74",
+    "effect_id": "50"
+  },
+  {
+    "﻿ingredient_id": "74",
+    "effect_id": "38"
+  },
+  {
+    "﻿ingredient_id": "74",
+    "effect_id": "23"
+  },
+  {
+    "﻿ingredient_id": "75",
+    "effect_id": "48"
+  },
+  {
+    "﻿ingredient_id": "75",
+    "effect_id": "36"
+  },
+  {
+    "﻿ingredient_id": "75",
+    "effect_id": "23"
+  },
+  {
+    "﻿ingredient_id": "75",
+    "effect_id": "31"
+  },
+  {
+    "﻿ingredient_id": "76",
+    "effect_id": "48"
+  },
+  {
+    "﻿ingredient_id": "76",
+    "effect_id": "10"
+  },
+  {
+    "﻿ingredient_id": "76",
+    "effect_id": "47"
+  },
+  {
+    "﻿ingredient_id": "76",
+    "effect_id": "45"
+  },
+  {
+    "﻿ingredient_id": "77",
+    "effect_id": "48"
+  },
+  {
+    "﻿ingredient_id": "77",
+    "effect_id": "19"
+  },
+  {
+    "﻿ingredient_id": "77",
+    "effect_id": "54"
+  },
+  {
+    "﻿ingredient_id": "77",
+    "effect_id": "45"
+  },
+  {
+    "﻿ingredient_id": "78",
+    "effect_id": "2"
+  },
+  {
+    "﻿ingredient_id": "78",
+    "effect_id": "49"
+  },
+  {
+    "﻿ingredient_id": "78",
+    "effect_id": "11"
+  },
+  {
+    "﻿ingredient_id": "78",
+    "effect_id": "7"
+  },
+  {
+    "﻿ingredient_id": "79",
+    "effect_id": "48"
+  },
+  {
+    "﻿ingredient_id": "79",
+    "effect_id": "26"
+  },
+  {
+    "﻿ingredient_id": "79",
+    "effect_id": "51"
+  },
+  {
+    "﻿ingredient_id": "79",
+    "effect_id": "7"
+  },
+  {
+    "﻿ingredient_id": "80",
+    "effect_id": "48"
+  },
+  {
+    "﻿ingredient_id": "80",
+    "effect_id": "26"
+  },
+  {
+    "﻿ingredient_id": "80",
+    "effect_id": "32"
+  },
+  {
+    "﻿ingredient_id": "80",
+    "effect_id": "42"
+  },
+  {
+    "﻿ingredient_id": "81",
+    "effect_id": "47"
+  },
+  {
+    "﻿ingredient_id": "81",
+    "effect_id": "36"
+  },
+  {
+    "﻿ingredient_id": "81",
+    "effect_id": "20"
+  },
+  {
+    "﻿ingredient_id": "81",
+    "effect_id": "2"
+  },
+  {
+    "﻿ingredient_id": "82",
+    "effect_id": "2"
+  },
+  {
+    "﻿ingredient_id": "82",
+    "effect_id": "8"
+  },
+  {
+    "﻿ingredient_id": "82",
+    "effect_id": "49"
+  },
+  {
+    "﻿ingredient_id": "82",
+    "effect_id": "11"
+  },
+  {
+    "﻿ingredient_id": "83",
+    "effect_id": "46"
+  },
+  {
+    "﻿ingredient_id": "83",
+    "effect_id": "22"
+  },
+  {
+    "﻿ingredient_id": "83",
+    "effect_id": "5"
+  },
+  {
+    "﻿ingredient_id": "83",
+    "effect_id": "53"
+  },
+  {
+    "﻿ingredient_id": "84",
+    "effect_id": "48"
+  },
+  {
+    "﻿ingredient_id": "84",
+    "effect_id": "16"
+  },
+  {
+    "﻿ingredient_id": "84",
+    "effect_id": "25"
+  },
+  {
+    "﻿ingredient_id": "84",
+    "effect_id": "54"
+  },
+  {
+    "﻿ingredient_id": "85",
+    "effect_id": "48"
+  },
+  {
+    "﻿ingredient_id": "85",
+    "effect_id": "50"
+  },
+  {
+    "﻿ingredient_id": "85",
+    "effect_id": "20"
+  },
+  {
+    "﻿ingredient_id": "85",
+    "effect_id": "39"
+  },
+  {
+    "﻿ingredient_id": "86",
+    "effect_id": "53"
+  },
+  {
+    "﻿ingredient_id": "86",
+    "effect_id": "24"
+  },
+  {
+    "﻿ingredient_id": "86",
+    "effect_id": "49"
+  },
+  {
+    "﻿ingredient_id": "86",
+    "effect_id": "39"
+  },
+  {
+    "﻿ingredient_id": "87",
+    "effect_id": "53"
+  },
+  {
+    "﻿ingredient_id": "87",
+    "effect_id": "17"
+  },
+  {
+    "﻿ingredient_id": "87",
+    "effect_id": "40"
+  },
+  {
+    "﻿ingredient_id": "87",
+    "effect_id": "11"
+  },
+  {
+    "﻿ingredient_id": "88",
+    "effect_id": "35"
+  },
+  {
+    "﻿ingredient_id": "88",
+    "effect_id": "37"
+  },
+  {
+    "﻿ingredient_id": "88",
+    "effect_id": "36"
+  },
+  {
+    "﻿ingredient_id": "88",
+    "effect_id": "31"
+  },
+  {
+    "﻿ingredient_id": "89",
+    "effect_id": "48"
+  },
+  {
+    "﻿ingredient_id": "89",
+    "effect_id": "6"
+  },
+  {
+    "﻿ingredient_id": "89",
+    "effect_id": "35"
+  },
+  {
+    "﻿ingredient_id": "89",
+    "effect_id": "42"
+  },
+  {
+    "﻿ingredient_id": "90",
+    "effect_id": "6"
+  },
+  {
+    "﻿ingredient_id": "90",
+    "effect_id": "35"
+  },
+  {
+    "﻿ingredient_id": "90",
+    "effect_id": "2"
+  },
+  {
+    "﻿ingredient_id": "90",
+    "effect_id": "18"
+  },
+  {
+    "﻿ingredient_id": "91",
+    "effect_id": "44"
+  },
+  {
+    "﻿ingredient_id": "91",
+    "effect_id": "23"
+  },
+  {
+    "﻿ingredient_id": "91",
+    "effect_id": "31"
+  },
+  {
+    "﻿ingredient_id": "91",
+    "effect_id": "27"
+  },
+  {
+    "﻿ingredient_id": "92",
+    "effect_id": "42"
+  },
+  {
+    "﻿ingredient_id": "92",
+    "effect_id": "31"
+  },
+  {
+    "﻿ingredient_id": "92",
+    "effect_id": "16"
+  },
+  {
+    "﻿ingredient_id": "92",
+    "effect_id": "10"
+  },
+  {
+    "﻿ingredient_id": "93",
+    "effect_id": "54"
+  },
+  {
+    "﻿ingredient_id": "93",
+    "effect_id": "24"
+  },
+  {
+    "﻿ingredient_id": "93",
+    "effect_id": "33"
+  },
+  {
+    "﻿ingredient_id": "93",
+    "effect_id": "2"
+  },
+  {
+    "﻿ingredient_id": "94",
+    "effect_id": "48"
+  },
+  {
+    "﻿ingredient_id": "94",
+    "effect_id": "22"
+  },
+  {
+    "﻿ingredient_id": "94",
+    "effect_id": "24"
+  },
+  {
+    "﻿ingredient_id": "94",
+    "effect_id": "42"
+  },
+  {
+    "﻿ingredient_id": "95",
+    "effect_id": "41"
+  },
+  {
+    "﻿ingredient_id": "95",
+    "effect_id": "14"
+  },
+  {
+    "﻿ingredient_id": "95",
+    "effect_id": "42"
+  },
+  {
+    "﻿ingredient_id": "95",
+    "effect_id": "45"
+  },
+  {
+    "﻿ingredient_id": "96",
+    "effect_id": "37"
+  },
+  {
+    "﻿ingredient_id": "96",
+    "effect_id": "41"
+  },
+  {
+    "﻿ingredient_id": "96",
+    "effect_id": "14"
+  },
+  {
+    "﻿ingredient_id": "96",
+    "effect_id": "36"
+  },
+  {
+    "﻿ingredient_id": "97",
+    "effect_id": "5"
+  },
+  {
+    "﻿ingredient_id": "97",
+    "effect_id": "4"
+  },
+  {
+    "﻿ingredient_id": "97",
+    "effect_id": "19"
+  },
+  {
+    "﻿ingredient_id": "97",
+    "effect_id": "21"
+  },
+  {
+    "﻿ingredient_id": "98",
+    "effect_id": "4"
+  },
+  {
+    "﻿ingredient_id": "98",
+    "effect_id": "14"
+  },
+  {
+    "﻿ingredient_id": "98",
+    "effect_id": "25"
+  },
+  {
+    "﻿ingredient_id": "98",
+    "effect_id": "8"
+  },
+  {
+    "﻿ingredient_id": "99",
+    "effect_id": "45"
+  },
+  {
+    "﻿ingredient_id": "99",
+    "effect_id": "32"
+  },
+  {
+    "﻿ingredient_id": "99",
+    "effect_id": "34"
+  },
+  {
+    "﻿ingredient_id": "99",
+    "effect_id": "46"
+  },
+  {
+    "﻿ingredient_id": "100",
+    "effect_id": "53"
+  },
+  {
+    "﻿ingredient_id": "100",
+    "effect_id": "17"
+  },
+  {
+    "﻿ingredient_id": "100",
+    "effect_id": "39"
+  },
+  {
+    "﻿ingredient_id": "100",
+    "effect_id": "47"
+  },
+  {
+    "﻿ingredient_id": "101",
+    "effect_id": "42"
+  },
+  {
+    "﻿ingredient_id": "101",
+    "effect_id": "37"
+  },
+  {
+    "﻿ingredient_id": "101",
+    "effect_id": "44"
+  },
+  {
+    "﻿ingredient_id": "101",
+    "effect_id": "16"
+  },
+  {
+    "﻿ingredient_id": "102",
+    "effect_id": "48"
+  },
+  {
+    "﻿ingredient_id": "102",
+    "effect_id": "32"
+  },
+  {
+    "﻿ingredient_id": "102",
+    "effect_id": "53"
+  },
+  {
+    "﻿ingredient_id": "102",
+    "effect_id": "27"
+  },
+  {
+    "﻿ingredient_id": "103",
+    "effect_id": "55"
+  },
+  {
+    "﻿ingredient_id": "103",
+    "effect_id": "11"
+  },
+  {
+    "﻿ingredient_id": "103",
+    "effect_id": "3"
+  },
+  {
+    "﻿ingredient_id": "103",
+    "effect_id": "49"
+  },
+  {
+    "﻿ingredient_id": "104",
+    "effect_id": "44"
+  },
+  {
+    "﻿ingredient_id": "104",
+    "effect_id": "28"
+  },
+  {
+    "﻿ingredient_id": "104",
+    "effect_id": "29"
+  },
+  {
+    "﻿ingredient_id": "104",
+    "effect_id": "2"
+  },
+  {
+    "﻿ingredient_id": "105",
+    "effect_id": "43"
+  },
+  {
+    "﻿ingredient_id": "105",
+    "effect_id": "20"
+  },
+  {
+    "﻿ingredient_id": "105",
+    "effect_id": "10"
+  },
+  {
+    "﻿ingredient_id": "105",
+    "effect_id": "9"
+  },
+  {
+    "﻿ingredient_id": "106",
+    "effect_id": "30"
+  },
+  {
+    "﻿ingredient_id": "106",
+    "effect_id": "47"
+  },
+  {
+    "﻿ingredient_id": "106",
+    "effect_id": "38"
+  },
+  {
+    "﻿ingredient_id": "106",
+    "effect_id": "1"
+  },
+  {
+    "﻿ingredient_id": "107",
+    "effect_id": "55"
+  },
+  {
+    "﻿ingredient_id": "107",
+    "effect_id": "43"
+  },
+  {
+    "﻿ingredient_id": "107",
+    "effect_id": "2"
+  },
+  {
+    "﻿ingredient_id": "107",
+    "effect_id": "20"
+  },
+  {
+    "﻿ingredient_id": "108",
+    "effect_id": "46"
+  },
+  {
+    "﻿ingredient_id": "108",
+    "effect_id": "15"
+  },
+  {
+    "﻿ingredient_id": "108",
+    "effect_id": "6"
+  },
+  {
+    "﻿ingredient_id": "108",
+    "effect_id": "32"
+  },
+  {
+    "﻿ingredient_id": "109",
+    "effect_id": "52"
+  },
+  {
+    "﻿ingredient_id": "109",
+    "effect_id": "16"
+  },
+  {
+    "﻿ingredient_id": "109",
+    "effect_id": "47"
+  },
+  {
+    "﻿ingredient_id": "109",
+    "effect_id": "36"
+  },
+  {
+    "﻿ingredient_id": "110",
+    "effect_id": "48"
+  },
+  {
+    "﻿ingredient_id": "110",
+    "effect_id": "13"
+  },
+  {
+    "﻿ingredient_id": "110",
+    "effect_id": "11"
+  },
+  {
+    "﻿ingredient_id": "110",
+    "effect_id": "43"
+  },
+  {
+    "﻿ingredient_id": "111",
+    "effect_id": "44"
+  },
+  {
+    "﻿ingredient_id": "111",
+    "effect_id": "24"
+  },
+  {
+    "﻿ingredient_id": "111",
+    "effect_id": "15"
+  },
+  {
+    "﻿ingredient_id": "111",
+    "effect_id": "6"
+  }
+]

--- a/src/assets/alchemy_ingredients.json
+++ b/src/assets/alchemy_ingredients.json
@@ -1,0 +1,557 @@
+[
+  {
+    "﻿Ingredient": "Abecean Longfin",
+    "id": "1",
+    "weight": "0.5"
+  },
+  {
+    "﻿Ingredient": "Ancestor Moth Wing*",
+    "id": "2",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Ash Creep Cluster",
+    "id": "3",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Ash Hopper Jelly",
+    "id": "4",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Ashen Grass Pod",
+    "id": "5",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Bear Claws",
+    "id": "6",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Bee",
+    "id": "7",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Beehive Husk",
+    "id": "8",
+    "weight": "1"
+  },
+  {
+    "﻿Ingredient": "Berit's Ashes(identical to Bone Meal)",
+    "id": "9",
+    "weight": "0.5"
+  },
+  {
+    "﻿Ingredient": "Bleeding Crown",
+    "id": "10",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Blisterwort",
+    "id": "11",
+    "weight": "0.2"
+  },
+  {
+    "﻿Ingredient": "Blue Butterfly Wing",
+    "id": "12",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Blue Dartwing",
+    "id": "13",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Blue Mountain Flower",
+    "id": "14",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Boar Tusk",
+    "id": "15",
+    "weight": "0.5"
+  },
+  {
+    "﻿Ingredient": "Bone Meal",
+    "id": "16",
+    "weight": "0.5"
+  },
+  {
+    "﻿Ingredient": "Briar Heart",
+    "id": "17",
+    "weight": "0.5"
+  },
+  {
+    "﻿Ingredient": "Burnt Spriggan Wood",
+    "id": "18",
+    "weight": "0.5"
+  },
+  {
+    "﻿Ingredient": "Butterfly Wing",
+    "id": "19",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Canis Root",
+    "id": "20",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Charred Skeever Hide",
+    "id": "21",
+    "weight": "0.5"
+  },
+  {
+    "﻿Ingredient": "Chaurus Eggs",
+    "id": "22",
+    "weight": "0.2"
+  },
+  {
+    "﻿Ingredient": "Chaurus Hunter Antennae*",
+    "id": "23",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Chicken's Egg",
+    "id": "24",
+    "weight": "0.5"
+  },
+  {
+    "﻿Ingredient": "Creep Cluster",
+    "id": "25",
+    "weight": "0.2"
+  },
+  {
+    "﻿Ingredient": "Crimson Nirnroot",
+    "id": "26",
+    "weight": "0.2"
+  },
+  {
+    "﻿Ingredient": "Cyrodilic Spadetail",
+    "id": "27",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Daedra Heart",
+    "id": "28",
+    "weight": "0.5"
+  },
+  {
+    "﻿Ingredient": "Deathbell",
+    "id": "29",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Dragon's Tongue",
+    "id": "30",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Dwarven Oil",
+    "id": "31",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Ectoplasm",
+    "id": "32",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Elves Ear",
+    "id": "33",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Emperor Parasol Moss",
+    "id": "34",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Eye of Sabre Cat",
+    "id": "35",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Falmer Ear",
+    "id": "36",
+    "weight": "0.2"
+  },
+  {
+    "﻿Ingredient": "Felsaad Tern Feathers",
+    "id": "37",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Fire Salts",
+    "id": "38",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Fly Amanita",
+    "id": "39",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Frost Mirriam",
+    "id": "40",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Frost Salts",
+    "id": "41",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Garlic",
+    "id": "42",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Giant Lichen",
+    "id": "43",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Giant's Toe",
+    "id": "44",
+    "weight": "1"
+  },
+  {
+    "﻿Ingredient": "Gleamblossom*",
+    "id": "45",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Glow Dust",
+    "id": "46",
+    "weight": "0.5"
+  },
+  {
+    "﻿Ingredient": "Glowing Mushroom",
+    "id": "47",
+    "weight": "0.2"
+  },
+  {
+    "﻿Ingredient": "Grass Pod",
+    "id": "48",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Hagraven Claw",
+    "id": "49",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Hagraven Feathers",
+    "id": "50",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Hanging Moss",
+    "id": "51",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Hawk Beak",
+    "id": "52",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Hawk Feathers",
+    "id": "53",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Hawk's Eggâ€ ",
+    "id": "54",
+    "weight": "0.5"
+  },
+  {
+    "﻿Ingredient": "Histcarp",
+    "id": "55",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Honeycomb",
+    "id": "56",
+    "weight": "1"
+  },
+  {
+    "﻿Ingredient": "Human Flesh",
+    "id": "57",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Human Heart",
+    "id": "58",
+    "weight": "1"
+  },
+  {
+    "﻿Ingredient": "Ice Wraith Teeth",
+    "id": "59",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Imp Stool",
+    "id": "60",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Jarrin Root",
+    "id": "61",
+    "weight": "0.5"
+  },
+  {
+    "﻿Ingredient": "Jazbay Grapes",
+    "id": "62",
+    "weight": "0.2"
+  },
+  {
+    "﻿Ingredient": "Juniper Berries",
+    "id": "63",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Large Antlers",
+    "id": "64",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Lavender",
+    "id": "65",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Luna Moth Wing",
+    "id": "66",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Moon Sugar",
+    "id": "67",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Mora Tapinella",
+    "id": "68",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Mudcrab Chitin",
+    "id": "69",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Namira's Rot",
+    "id": "70",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Netch Jelly",
+    "id": "71",
+    "weight": "0.5"
+  },
+  {
+    "﻿Ingredient": "Nightshade",
+    "id": "72",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Nirnroot",
+    "id": "73",
+    "weight": "0.2"
+  },
+  {
+    "﻿Ingredient": "Nordic Barnacle",
+    "id": "74",
+    "weight": "0.2"
+  },
+  {
+    "﻿Ingredient": "Orange Dartwing",
+    "id": "75",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Pearl",
+    "id": "76",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Pine Thrush Egg",
+    "id": "77",
+    "weight": "0.5"
+  },
+  {
+    "﻿Ingredient": "Poison Bloom*",
+    "id": "78",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Powdered Mammoth Tusk",
+    "id": "79",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Purple Mountain Flower",
+    "id": "80",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Red Mountain Flower",
+    "id": "81",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "River Betty",
+    "id": "82",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Rock Warbler Egg",
+    "id": "83",
+    "weight": "0.5"
+  },
+  {
+    "﻿Ingredient": "Sabre Cat Tooth",
+    "id": "84",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Salmon Roeâ€ ",
+    "id": "85",
+    "weight": "0.2"
+  },
+  {
+    "﻿Ingredient": "Salt Pile",
+    "id": "86",
+    "weight": "0.2"
+  },
+  {
+    "﻿Ingredient": "Scaly Pholiota",
+    "id": "87",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Scathecraw",
+    "id": "88",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Silverside Perch",
+    "id": "89",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Skeever Tail",
+    "id": "90",
+    "weight": "0.2"
+  },
+  {
+    "﻿Ingredient": "Slaughterfish Egg",
+    "id": "91",
+    "weight": "0.2"
+  },
+  {
+    "﻿Ingredient": "Slaughterfish Scales",
+    "id": "92",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Small Antlers",
+    "id": "93",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Small Pearl",
+    "id": "94",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Snowberries",
+    "id": "95",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Spawn Ash",
+    "id": "96",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Spider Egg",
+    "id": "97",
+    "weight": "0.2"
+  },
+  {
+    "﻿Ingredient": "Spriggan Sap",
+    "id": "98",
+    "weight": "0.2"
+  },
+  {
+    "﻿Ingredient": "Swamp Fungal Pod",
+    "id": "99",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Taproot",
+    "id": "100",
+    "weight": "0.5"
+  },
+  {
+    "﻿Ingredient": "Thistle Branch",
+    "id": "101",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Torchbug Thorax",
+    "id": "102",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Trama Root",
+    "id": "103",
+    "weight": "0.2"
+  },
+  {
+    "﻿Ingredient": "Troll Fat",
+    "id": "104",
+    "weight": "1"
+  },
+  {
+    "﻿Ingredient": "Tundra Cotton",
+    "id": "105",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Vampire Dust",
+    "id": "106",
+    "weight": "0.2"
+  },
+  {
+    "﻿Ingredient": "Void Salts",
+    "id": "107",
+    "weight": "0.2"
+  },
+  {
+    "﻿Ingredient": "Wheat",
+    "id": "108",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "White Cap",
+    "id": "109",
+    "weight": "0.3"
+  },
+  {
+    "﻿Ingredient": "Wisp Wrappings",
+    "id": "110",
+    "weight": "0.1"
+  },
+  {
+    "﻿Ingredient": "Yellow Mountain Flower*",
+    "id": "111",
+    "weight": "0.1"
+  }
+]

--- a/src/data/alchemy.js
+++ b/src/data/alchemy.js
@@ -1,0 +1,31 @@
+import rawIngredients from '../assets/alchemy_ingredients.json';
+import rawEffects from '../assets/alchemy_effects.json';
+import rawIngredientEffects from '../assets/alchemy_ingredient_effects.json';
+
+const effects = rawEffects.map(e => ({
+  id: Number(e.id),
+  name: e['\ufeffname'] || e.name,
+}));
+
+const ingredients = rawIngredients.map(i => ({
+  id: Number(i.id),
+  name: i['\ufeffIngredient'] || i.Ingredient,
+  weight: Number(i.weight),
+}));
+
+const ingredientEffects = rawIngredientEffects.map(ie => ({
+  ingredientId: Number(ie['\ufeffingredient_id'] || ie.ingredient_id),
+  effectId: Number(ie.effect_id),
+}));
+
+const effectsById = Object.fromEntries(effects.map(e => [e.id, e.name]));
+
+const ingredientsWithEffects = ingredients.map(ing => ({
+  ...ing,
+  effects: ingredientEffects
+    .filter(ie => ie.ingredientId === ing.id)
+    .map(ie => effectsById[ie.effectId])
+    .sort(),
+}));
+
+export { ingredientsWithEffects as ingredients, effects };

--- a/src/lib/alchemy.js
+++ b/src/lib/alchemy.js
@@ -1,0 +1,42 @@
+// Utility functions for alchemy calculations
+
+// Return ingredients that have at least one of the selected effects
+export function ingredientsForEffects(selectedEffects, allIngredients) {
+  return allIngredients.filter(ing =>
+    ing.effects.some(eff => selectedEffects.includes(eff)),
+  );
+}
+
+// Generate all valid potions from a list of ingredients
+export function possiblePotions(ingredientList) {
+  const combos = [];
+  for (let i = 0; i < ingredientList.length; i++) {
+    for (let j = i + 1; j < ingredientList.length; j++) {
+      const sharedTwo = intersect(ingredientList[i].effects, ingredientList[j].effects);
+      if (sharedTwo.length) {
+        combos.push({
+          ingredients: [ingredientList[i].name, ingredientList[j].name],
+          effects: sharedTwo,
+        });
+      }
+      for (let k = j + 1; k < ingredientList.length; k++) {
+        const sharedThree = intersect(sharedTwo, ingredientList[k].effects);
+        if (sharedThree.length) {
+          combos.push({
+            ingredients: [
+              ingredientList[i].name,
+              ingredientList[j].name,
+              ingredientList[k].name,
+            ],
+            effects: sharedThree,
+          });
+        }
+      }
+    }
+  }
+  return combos;
+}
+
+function intersect(a, b) {
+  return a.filter(x => b.includes(x));
+}

--- a/src/pages/AlchemyCalculator.jsx
+++ b/src/pages/AlchemyCalculator.jsx
@@ -1,55 +1,103 @@
-import { useState } from 'react'
-import { StateLink } from 'ygdrassil'
+import { useState } from 'react';
+import { StateLink } from 'ygdrassil';
+import { ingredients, effects } from '../data/alchemy';
+import { ingredientsForEffects, possiblePotions } from '../lib/alchemy';
 
-const potions = [
-  { name: 'Health Potion', ingredients: ['Blue Mountain Flower', 'Wheat'] },
-  { name: 'Fortify Smithing', ingredients: ['Blisterwort', 'Spriggan Sap'] },
-  { name: 'Fortify Barter', ingredients: ['Tundra Cotton', 'Blue Butterfly Wing'] },
-]
+function Checklist({ items, selected, toggle }) {
+  return (
+    <div style={{ maxHeight: '200px', overflowY: 'auto' }}>
+      {items.map(item => (
+        <label key={item.name} style={{ display: 'block' }}>
+          <input
+            type="checkbox"
+            checked={selected.includes(item.name)}
+            onChange={() => toggle(item.name)}
+          />
+          {item.name}
+        </label>
+      ))}
+    </div>
+  );
+}
 
-const allIngredients = Array.from(new Set(potions.flatMap(p => p.ingredients))).sort()
+function Results({ combos }) {
+  return (
+    <div>
+      <h3>Combinations</h3>
+      {combos.length ? (
+        <ul>
+          {combos.map((c, i) => (
+            <li key={i}>
+              {c.ingredients.join(', ')} → {c.effects.join(', ')}
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p>No valid combinations.</p>
+      )}
+    </div>
+  );
+}
 
 export default function AlchemyCalculator() {
-  const [selected, setSelected] = useState([])
+  const [mode, setMode] = useState('ingredients');
+  const [selected, setSelected] = useState([]);
 
-  const toggleIngredient = (ing) => {
+  const toggle = name => {
     setSelected(prev =>
-      prev.includes(ing) ? prev.filter(i => i !== ing) : [...prev, ing],
-    )
+      prev.includes(name) ? prev.filter(n => n !== name) : [...prev, name],
+    );
+  };
+
+  let combos = [];
+  if (mode === 'ingredients') {
+    const chosen = ingredients.filter(ing => selected.includes(ing.name));
+    combos = possiblePotions(chosen);
+  } else {
+    const chosenEffects = selected;
+    const candidates = ingredientsForEffects(chosenEffects, ingredients);
+    combos = possiblePotions(candidates).filter(c =>
+      chosenEffects.every(eff => c.effects.includes(eff)),
+    );
   }
 
-  const results = potions.filter(p => p.ingredients.every(ing => selected.includes(ing)))
+  const list = mode === 'ingredients' ? ingredients : effects;
 
   return (
     <div>
       <h2>Alchemy Calculator</h2>
-      <p>Select ingredients to see matching potions.</p>
-      <div>
-        {allIngredients.map(ing => (
-          <label key={ing} style={{ display: 'block' }}>
-            <input
-              type="checkbox"
-              checked={selected.includes(ing)}
-              onChange={() => toggleIngredient(ing)}
-            />
-            {ing}
-          </label>
-        ))}
+      <div style={{ marginBottom: '1em' }}>
+        <label>
+          <input
+            type="radio"
+            name="mode"
+            value="ingredients"
+            checked={mode === 'ingredients'}
+            onChange={() => {
+              setMode('ingredients');
+              setSelected([]);
+            }}
+          />
+          By Ingredients
+        </label>
+        {' '}
+        <label>
+          <input
+            type="radio"
+            name="mode"
+            value="effects"
+            checked={mode === 'effects'}
+            onChange={() => {
+              setMode('effects');
+              setSelected([]);
+            }}
+          />
+          By Effects
+        </label>
       </div>
-      <div>
-        <h3>Matching Potions</h3>
-        {results.length ? (
-          <ul>
-            {results.map(p => (
-              <li key={p.name}>{p.name}</li>
-            ))}
-          </ul>
-        ) : (
-          <p>No potions match the selected ingredients.</p>
-        )}
-      </div>
+      <Checklist items={list} selected={selected} toggle={toggle} />
+      <Results combos={combos} />
       <StateLink to="landing">Back to menu</StateLink>
     </div>
-  )
+  );
 }
-


### PR DESCRIPTION
## Summary
- load ingredient/effect data into app build
- compute valid potions from ingredients or selected effects
- expose UI to toggle between ingredient and effect search modes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb2d22d83483279cfa636816bb3858