### PR TITLE
feat: add alchemy ingredient/effect filtering

### DIFF
--- a/assets/csv2json.js
+++ b/assets/csv2json.js
@@ -1,9 +1,11 @@
 // csv-to-json.mjs
+/* eslint-env node */
 import fs from 'fs';
 import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
 const csv = require('csv-parser');
 
+/* global process */
 const inputFile = process.argv[2] || 'input.csv';
 const outputFile = process.argv[3] || 'output.json';
 


### PR DESCRIPTION
## Summary
- replace potion mockup with full ingredient and effect lists
- allow multi-select filtering with clear buttons and effect-value sorting
- document Node usage in csv-to-json utility to satisfy linting

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c079ab53fc83278d57758e4754a770