### PR TITLE
Render potion permutations in table

### DIFF
--- a/src/pages/AlchemyCalculator.jsx
+++ b/src/pages/AlchemyCalculator.jsx
@@ -145,20 +145,32 @@ export default function AlchemyCalculator() {
         <div>
           <h3>Permutations</h3>
           {permutations.length ? (
-            <ul>
-              {permutations.map((perm, i) => (
-                <li key={i}>
-                  {perm.ids
-                    .map(id => ingredients.find(ing => ing.id === id)?.name)
-                    .join(' + ')}
-                  {` (`}
-                  {perm.effects
-                    .map(eid => effectMap[eid]?.name)
-                    .join(', ')}
-                  {`)`}
-                </li>
-              ))}
-            </ul>
+            <table>
+              <thead>
+                <tr>
+                  <th>Ingredient 1</th>
+                  <th>Ingredient 2</th>
+                  <th>Ingredient 3</th>
+                  <th>Effects</th>
+                </tr>
+              </thead>
+              <tbody>
+                {permutations.map((perm, i) => (
+                  <tr key={i}>
+                    {[0, 1, 2].map(idx => (
+                      <td key={idx}>
+                        {ingredients.find(ing => ing.id === perm.ids[idx])?.name || ''}
+                      </td>
+                    ))}
+                    <td>
+                      {perm.effects
+                        .map(eid => effectMap[eid]?.name)
+                        .join(', ')}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
           ) : (
             <p>No permutations match the selection.</p>
           )}


### PR DESCRIPTION
## Summary
- Display permutation results in a table with up to three ingredient columns and an effects column on the right

## Testing
- ⚠️ `npm test` (missing script)
- ✅ `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c08c82c90c83278bf9fc493e43a10b