### PR TITLE
chore: set Vite base URL to /skyrim

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -3,5 +3,6 @@ import react from '@vitejs/plugin-react-swc'
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: '/skyrim/',
   plugins: [react()],
 })


### PR DESCRIPTION
## Summary
- configure Vite's base path for deployment under `/skyrim`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c4896312ec83278311ebe7f57f9e55