### PR TITLE
Add select all button for alchemy ingredients

### DIFF
--- a/src/pages/AlchemyCalculator.jsx
+++ b/src/pages/AlchemyCalculator.jsx
@@ -123,7 +123,16 @@ export default function AlchemyCalculator() {
       >
         <div className={style.ingredients}>
           <h3>Ingredients</h3>
-          <button onClick={() => clear(setSelectedIngredients)}>Clear</button>
+          <div className={style.actionRow}>
+            <button onClick={() => clear(setSelectedIngredients)}>Clear</button>
+            <button
+              onClick={() =>
+                setSelectedIngredients(ingredients.map(ing => ing.id))
+              }
+            >
+              Select All
+            </button>
+          </div>
           {sortedIngredients.map(ing => (
             <label key={ing.id} className={style.ingredient}>
               <input

--- a/src/style/alchemy.module.css
+++ b/src/style/alchemy.module.css
@@ -18,6 +18,12 @@
   white-space: nowrap;
 }
 
+.actionRow {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
 .effects {
   max-height: 80vh;
   overflow-y: auto;


### PR DESCRIPTION
## Summary
- add a Select All button to quickly check every alchemy ingredient
- group the ingredient actions together with consistent spacing styles

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5859dc2048327bfd5188784d19ee1